### PR TITLE
[#1065] Fixed failing GitHub notifications.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -92,10 +92,11 @@ tasks:
           DREVOPS_NOTIFY_EVENT=post_deployment \
           DREVOPS_NOTIFY_PROJECT=$LAGOON_PROJECT \
           DREVOPS_NOTIFY_ENVIRONMENT_URL=$LAGOON_ROUTE \
-          ./scripts/drevops/notify.sh
+          ./scripts/drevops/notify.sh || true
         service: cli
         shell: bash
     #;> !NOTIFICATIONS
+
 environments:
   # Branch name that represents production environment.
   main:

--- a/.scaffold/.ahoy.yml
+++ b/.scaffold/.ahoy.yml
@@ -28,6 +28,11 @@ commands:
       ahoy test-common
       ahoy test-docs
 
+  test-bats:
+    cmd: |
+      [ ! -d tests/node_modules ] && ahoy install
+      tests/node_modules/.bin/bats "$@"
+
   test-common:
     cmd: ./tests/test.common.sh
 

--- a/.scaffold/docs/content/workflows/variables.mdx
+++ b/.scaffold/docs/content/workflows/variables.mdx
@@ -931,11 +931,11 @@ Defined in: `scripts/drevops/mirror-code.sh`
 
 ### `DREVOPS_NOTIFY_BRANCH`
 
-Deployment reference, such as a git SHA.
+Deployment reference branch.
 
 Default value: `UNDEFINED`
 
-Defined in: `scripts/drevops/notify-jira.sh`
+Defined in: `scripts/drevops/notify-github.sh`, `scripts/drevops/notify-jira.sh`
 
 ### `DREVOPS_NOTIFY_CHANNELS`
 
@@ -1167,11 +1167,11 @@ Defined in: `scripts/drevops/notify-webhook.sh`, `scripts/drevops/notify.sh`
 
 ### `DREVOPS_NOTIFY_REF`
 
-Deployment reference, such as a git SHA.
+Git reference to notify about.
 
 Default value: `UNDEFINED`
 
-Defined in: `scripts/drevops/notify-github.sh`, `scripts/drevops/notify-webhook.sh`
+Defined in: `scripts/drevops/notify-webhook.sh`
 
 ### `DREVOPS_NOTIFY_REPOSITORY`
 

--- a/hooks/library/notify-deployment.sh
+++ b/hooks/library/notify-deployment.sh
@@ -31,6 +31,6 @@ export DREVOPS_NOTIFY_REF="${ref}"
 export DREVOPS_NOTIFY_SHA="${target_env}"
 export DREVOPS_NOTIFY_ENVIRONMENT_URL="${url}"
 
-./scripts/drevops/notify.sh
+./scripts/drevops/notify.sh || true
 
 popd >/dev/null || exit 1


### PR DESCRIPTION
Closes #1065

The root cause was related to the fact that a Git ref was used instead of a branch name for PRs.

From https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28
> `ref` string
The name of the ref. This can be a branch, tag, or SHA.

The script was using `DREVOPS_NOTIFY_REF` instead of `DREVOPS_NOTIFY_BRANCH` for PRs. This PR fixes that.

It also adds 2 more changes:
1. More verbose messages on failures + tests.
2. **Failed notifications are now NOT blocking deployments.** This is to allow to deploy into hosting without waiting for the CI to pass (setting the deployment environment status for the PR without all checks passed will fail).
With the now additionally expanded messages, this should provide enough information 