### PR TITLE
Fixed to use correct deploy PR flag with Lagoon CLI 0.30.

### DIFF
--- a/scripts/drevops/deploy-lagoon.sh
+++ b/scripts/drevops/deploy-lagoon.sh
@@ -154,7 +154,7 @@ else
       fi
 
       note "Redeploying environment: project ${LAGOON_PROJECT}, PR: ${DREVOPS_DEPLOY_PR}."
-      lagoon deploy pullrequest -n "${DREVOPS_DEPLOY_PR}" --baseBranchName "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -R "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -H "${DREVOPS_DEPLOY_BRANCH}" -M "${DREVOPS_DEPLOY_PR_HEAD}" -t "${deploy_pr_full}"
+      lagoon deploy pullrequest -n "${DREVOPS_DEPLOY_PR}" -N "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -R "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -H "${DREVOPS_DEPLOY_BRANCH}" -M "${DREVOPS_DEPLOY_PR_HEAD}" -t "${deploy_pr_full}"
 
       if [ "${DREVOPS_DEPLOY_ACTION:-}" = "deploy_override_db" ]; then
         note "Waiting for deployment to be queued."
@@ -169,7 +169,7 @@ else
     else
       # If PR deployments are not configured in Lagoon - it will filter it out and will not deploy.
       note "Deploying environment: project ${LAGOON_PROJECT}, PR: ${DREVOPS_DEPLOY_PR}."
-      lagoon deploy pullrequest -n "${DREVOPS_DEPLOY_PR}" --baseBranchName "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -R "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -H "${DREVOPS_DEPLOY_BRANCH}" -M "${DREVOPS_DEPLOY_PR_HEAD}" -t "${deploy_pr_full}"
+      lagoon deploy pullrequest -n "${DREVOPS_DEPLOY_PR}" -N "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -R "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -H "${DREVOPS_DEPLOY_BRANCH}" -M "${DREVOPS_DEPLOY_PR_HEAD}" -t "${deploy_pr_full}"
     fi
 
   # Deploy branch.


### PR DESCRIPTION
On-behalf-of: @salsadigitalauorg <sonny.kieu@salsa.digital>

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[#123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Fixed issue with Lagoon CLI 0.30

```
+ command lagoon --force --skip-update-check -i /root/.ssh/id_rsa_xxx -l amazeeio -p xxx deploy pullrequest -n 1219 --baseBranchName develop -R origin/develop -H feature/XXX -M 5cbf1699887c5cf3092b3ef3e61c344fa51aeec9 -t pr-1219
Error: unknown flag: --baseBranchName
Usage:
  lagoon deploy pullrequest [flags]

Aliases:
  pullrequest, r

Flags:
  -N, --base-branch-name string   Pullrequest base branch name
  -R, --base-branch-ref string    Pullrequest base branch reference hash
      --buildvar stringArray      Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])
  -H, --head-branch-name string   Pullrequest head branch name
  -M, --head-branch-ref string    Pullrequest head branch reference hash
  -h, --help                      help for pullrequest
  -n, --number uint               Pullrequest number
      --returndata                Returns the build name instead of success text
  -t, --title string              Pullrequest title
```

## Screenshots
